### PR TITLE
Send datagen PGNs to an external server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 *.pyc
 Client/*
 OpenBench/migrations/*

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -377,7 +377,7 @@ class ServerReporter:
         # send pgn to external server here
         requests.post("https://pgn.int0x80.ca", data=compressed_pgn_text)
 
-        return ServerReporter.report(config, 'clientSubmitPGN', payload, files)
+        return True
 
 class Cutechess:
 

--- a/Client/worker.py
+++ b/Client/worker.py
@@ -374,6 +374,9 @@ class ServerReporter:
             'file' : ('games.pgn', compressed_pgn_text)
         }
 
+        # send pgn to external server here
+        requests.post("https://pgn.int0x80.ca", data=compressed_pgn_text)
+
         return ServerReporter.report(config, 'clientSubmitPGN', payload, files)
 
 class Cutechess:

--- a/OpenBench/views.py
+++ b/OpenBench/views.py
@@ -755,19 +755,7 @@ def client_heartbeat(request, machine):
 @csrf_exempt
 @verify_worker
 def client_submit_pgn(request, machine):
-
-    with transaction.atomic():
-
-        # Format: test.result.book-index.pgn.bz2
-        pgn            = PGN()
-        pgn.test_id    = int(request.POST['test_id']   )
-        pgn.result_id  = int(request.POST['result_id'] )
-        pgn.book_index = int(request.POST['book_index'])
-        pgn.save()
-
-        # Save the .pgn.bz2 to /Media/
-        FileSystemStorage().save(pgn.filename(), ContentFile(request.FILES['file'].read()))
-
+    # for this branch, do nothing because PGNs are being uploaded to a different endpoint
     return JsonResponse({})
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
The instance runs on a free PythonAnywhere instance, which is free (obviously), but comes with the downside of only 512MB of storage.

This change sends the PGNs to an external server for storage.